### PR TITLE
opam2: buildable for MirageOS

### DIFF
--- a/actor.opam
+++ b/actor.opam
@@ -1,4 +1,5 @@
-opam-version: "1.2"
+opam-version: "2.0"
+name: "actor"
 maintainer: "Liang Wang (ryanrhymes@gmail.com)"
 authors: [ "Liang Wang (ryanrhymes@gmail.com)" ]
 license: "MIT"
@@ -6,23 +7,23 @@ homepage: "https://github.com/ryanrhymes/light_actor/"
 dev-repo: "git+https://github.com/ryanrhymes/light_actor.git"
 bug-reports: "https://github.com/ryanrhymes/light_actor/issues"
 doc: "http://www.cl.cam.ac.uk/~lw525/"
-
+synopsis: "A distributed data processing system developed in OCaml"
 version: "dev"
 
 build: [
-  ["dune" "subst" "-n" name] {pinned}
+  ["dune" "subst"] {pinned}
   ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
 ]
-build-test: [["dune" "runtest" "-p" name "-j" jobs]]
 
 depexts: [
   "zmq"
 ]
 
 depends: [
+  "ocaml" {>= "4.04.0"}
   "dune" {build}
   "ocamlgraph"
   "owl"
   "zmq"
 ]
-available: [ ocaml-version >= "4.04.0" ]

--- a/actor_mirage.opam
+++ b/actor_mirage.opam
@@ -1,0 +1,27 @@
+opam-version: "2.0"
+name: "actor_unix"
+maintainer: "Liang Wang (ryanrhymes@gmail.com)"
+authors: [ "Liang Wang (ryanrhymes@gmail.com)" ]
+license: "MIT"
+homepage: "https://github.com/ryanrhymes/light_actor/"
+dev-repo: "git+https://github.com/ryanrhymes/light_actor.git"
+bug-reports: "https://github.com/ryanrhymes/light_actor/issues"
+doc: "http://www.cl.cam.ac.uk/~lw525/"
+synopsis: "A distributed data processing system developed in OCaml"
+version: "dev"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depexts: [
+  "zmq"
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "ocamlgraph"
+]

--- a/actor_unix.opam
+++ b/actor_unix.opam
@@ -1,0 +1,29 @@
+opam-version: "2.0"
+name: "actor_unix"
+maintainer: "Liang Wang (ryanrhymes@gmail.com)"
+authors: [ "Liang Wang (ryanrhymes@gmail.com)" ]
+license: "MIT"
+homepage: "https://github.com/ryanrhymes/light_actor/"
+dev-repo: "git+https://github.com/ryanrhymes/light_actor.git"
+bug-reports: "https://github.com/ryanrhymes/light_actor/issues"
+doc: "http://www.cl.cam.ac.uk/~lw525/"
+synopsis: "A distributed data processing system developed in OCaml"
+version: "dev"
+
+build: [
+  ["dune" "subst"] {pinned}
+  ["dune" "build" "-p" name "-j" jobs]
+  ["dune" "runtest" "-p" name "-j" jobs] {with-test}
+]
+
+depexts: [
+  "zmq"
+]
+
+depends: [
+  "ocaml" {>= "4.04.0"}
+  "dune" {build}
+  "ocamlgraph"
+  "owl"
+  "zmq"
+]

--- a/src/mirage/actor_sys_mirage.ml
+++ b/src/mirage/actor_sys_mirage.ml
@@ -3,4 +3,5 @@
  * Copyright (c) 2016-2019 Liang Wang <liang.wang@cl.cam.ac.uk>
  *)
 
-let sleep = Lwt_unix.sleep
+let sleep delay =
+  Mirage_OS.OS.Time.sleep_ns (Duration.of_sec (int_of_float delay))

--- a/src/mirage/dune
+++ b/src/mirage/dune
@@ -6,5 +6,7 @@
   (preprocess (pps lwt.ppx))
   (libraries
     mirage-time-lwt
+    mirage-os-shim
+    duration
   )
 )


### PR DESCRIPTION
MirageOS requires opam2, which requires some updates of packaing.
For later Unikernel'ization, all unix dependency should be removed from MirageOS backend.