### PR TITLE
test/mirage: add scripts to run lwae hvt

### DIFF
--- a/test/mirage/net
+++ b/test/mirage/net
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+[ -z "$maxtap" ] && maxtap=3
+[ -z "$hostif" ] && hostif="ens3"
+
+function up() {
+    ip link add br0 type bridge
+    ip addr add 192.168.0.100/24 dev br0
+    ip link set dev br0 up
+    ip addr show br0
+
+    for x in $(seq $maxtap); do
+        ip tuntap add dev tap$x mode tap user $USER
+        ip link set tap$x master br0
+        ip link set dev tap$x up
+        ip addr show tap$x
+    done
+    iptables -P FORWARD ACCEPT
+    iptables -t nat -A POSTROUTING -s 192.168.0.0/24 -o $hostif -j MASQUERADE
+}
+
+function down() {
+
+    for x in $(seq $maxtap); do
+        ip link delete tap$x
+    done
+    ip link delete br0
+    iptables -P FORWARD DROP
+    ip addr show
+}
+
+if [ "$1" = "up" ]; then
+    up
+elif [ "$1" = "down" ]; then
+    down
+else
+    echo "Usage: $0 {up|down}" >&2
+    exit 123
+fi

--- a/test/mirage/start-actor
+++ b/test/mirage/start-actor
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+uuid=$1
+case $1 in
+    "server")
+        n=1
+        ;;
+    "w0")
+        n=2
+        ;;
+    "w1")
+        n=3
+        ;;
+esac
+
+./solo5-hvt --net=tap$n lwae.hvt \
+            --ipv4=192.168.0.$n/24 \
+            --ip=192.168.0.$n \
+            --server_ip=192.168.0.1 \
+            --uuid=$uuid \
+            --port=600$n


### PR DESCRIPTION
The following example shows how to run "lwae hvt" on your local machine.

 Usage:
   $ ./net up
   $ ./start-actor "server"
   $ ./start-actor "w0"
   $ ./start-actor "w1"
   $ ./net down

The above sets up the following:

 "server" on tap1, 192.168.0.1/24
     "w1" on tap2, 192.168.0.2/24
     "w2" on tap3, 192.168.0.3/24
             br0,  192.168.0.100/24

Signed-off-by: Hiroshi Doyu <hiroshi.doyu@ericsson.com>